### PR TITLE
Attach arrows to cards

### DIFF
--- a/src/client/app/graph/arrow/arrow.component.css
+++ b/src/client/app/graph/arrow/arrow.component.css
@@ -1,0 +1,4 @@
+
+polygon, polyline {
+  cursor: pointer;
+}

--- a/src/client/app/graph/arrow/arrow.component.html
+++ b/src/client/app/graph/arrow/arrow.component.html
@@ -1,4 +1,7 @@
-<svg:g x="0" y="0">
+<svg:g x="0"
+       y="0"
+       xmlns:xhtml="http://www.w3.org/1999/xhtml"
+       (mousedown)="this.onMousedown($event)">
   <polygon vector-effect="non-scaling-stroke"
            fill="#f00"
            stroke="#f00"

--- a/src/client/app/graph/arrow/arrow.component.ts
+++ b/src/client/app/graph/arrow/arrow.component.ts
@@ -35,7 +35,7 @@ export class ArrowComponent implements OnInit {
   // Whether or not tip dragging is in progress.
   private tipDragging: boolean = false;
   // The last point seen during the drag that is currently in progress.
-  private lastDragPnt: ViewportCoord = null; //TODO(eyuelt): make this nullable after TS2 update
+  private lastDragPoint: ViewportCoord = null; //TODO(eyuelt): make this nullable after TS2 update
 
   constructor(private canvasService: CanvasService,
               private googleRealtimeService: GoogleRealtimeService) {
@@ -89,11 +89,14 @@ export class ArrowComponent implements OnInit {
     return pointsStr;
   }
 
+  // TODO(eyuelt): increase arrow hitbox
+  // TODO(eyuelt): put the mousedown listener on the tip of the arrow, otherwise
+  // dragging anywhere on the arrow will move the tip
   onMousedown(event: MouseEvent) {
     if (EventUtils.eventIsFromPrimaryButton(event)) {
       this.tipDragging = true;
       const canvasBounds = this.canvasBoundsGetter();
-      this.lastDragPnt = {
+      this.lastDragPoint = {
         x: event.clientX - canvasBounds.left,
         y: event.clientY - canvasBounds.top
       };
@@ -107,16 +110,18 @@ export class ArrowComponent implements OnInit {
     if (this.tipDragging) {
       event.preventDefault();
       const canvasBounds = this.canvasBoundsGetter();
-      const newDragPnt = {
+      const newDragPoint = {
         x: event.clientX - canvasBounds.left,
         y: event.clientY - canvasBounds.top
       };
-      this.tipPosition.x += newDragPnt.x - this.lastDragPnt.x;
-      this.tipPosition.y += newDragPnt.y - this.lastDragPnt.y;
+      this.tipPosition = {
+        x: this.tipPosition.x + newDragPoint.x - this.lastDragPoint.x,
+        y: this.tipPosition.y + newDragPoint.y - this.lastDragPoint.y
+      }
       const newTipPosition =
         this.canvasService.viewportCoordToCanvasCoord(this.tipPosition);
       this.arrow.tipPosition = {x: newTipPosition.x, y: newTipPosition.y};
-      this.lastDragPnt = newDragPnt;
+      this.lastDragPoint = newDragPoint;
     }
   }
 
@@ -151,7 +156,7 @@ export class ArrowComponent implements OnInit {
         // TODO(eyuelt): reposition the arrow
       }
       this.tipDragging = false;
-      this.lastDragPnt = null;
+      this.lastDragPoint = null;
     }
   }
 

--- a/src/client/app/graph/arrow/arrow.component.ts
+++ b/src/client/app/graph/arrow/arrow.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, HostListener } from '@angular/core';
-import { CanvasService, ViewportCoord } from '../canvas/canvas.service';
+import { CanvasService, ViewportCoord, ArrowConnectionType } from '../canvas/canvas.service';
 import {
   GoogleRealtimeService,
   OBJECT_CHANGED
@@ -120,11 +120,36 @@ export class ArrowComponent implements OnInit {
     }
   }
 
+  // Finds the first element in the given list that is a descendant of a
+  // uxg-card and returns the ancestor uxg-card element. Returns null if
+  // no such element exists.
+  // TODO(eyuelt): optimize this if needed
+  // TODO(eyuelt): move this somewhere else
+  private topCardElementFromList(elements: Element[]): Element {
+    for (let element of elements) {
+      while (element !== null) {
+        if (element.hasAttribute('uxg-card')) {
+          return element;
+        }
+        element = element.parentElement;
+      }
+    }
+    return null;
+  }
+
   // Put mouseup on document to end drag even if mouseup is outside of canvas
   //noinspection JSUnusedGlobalSymbols,JSUnusedLocalSymbols
   @HostListener('document:mouseup', ['$event'])
   onMouseup(event: MouseEvent) {
     if (this.tipDragging) {
+      const topCard = this.topCardElementFromList(document.elementsFromPoint(event.clientX, event.clientY));
+      if (topCard !== null) {
+        const cardId = topCard.getAttribute('card-id');
+        console.log('clicked on card id: ' + cardId);
+        const card = this.canvasService.getCardById(cardId);
+        this.canvasService.connectArrowAndCard(this.arrow, card, ArrowConnectionType.INCOMING);
+        // TODO(eyuelt): reposition the arrow
+      }
       this.tipDragging = false;
       this.lastDragPnt = null;
     }

--- a/src/client/app/graph/canvas/canvas.component.html
+++ b/src/client/app/graph/canvas/canvas.component.html
@@ -6,7 +6,8 @@
      (mousewheel)="this.onMousewheel($event)">
   <g uxg-arrow
      *ngFor="let arrow of (this.canvasService.arrows | toIterable)"
-     [arrow]="arrow"></g>
+     [arrow]="arrow"
+     [canvasBoundsGetter]="getBounds"></g>
   <g uxg-card
      *ngFor="let card of (this.canvasService.cards | toIterable)"
      [card]="card"

--- a/src/client/app/graph/canvas/canvas.service.ts
+++ b/src/client/app/graph/canvas/canvas.service.ts
@@ -14,6 +14,11 @@ export type ViewportCoord = Point;
 // A point in the coordinate system of the canvas.
 export type CanvasCoord = Point;
 
+// Specifies the type of connection an arrow has to a card.
+export enum ArrowConnectionType {
+  INCOMING,
+  OUTGOING
+}
 
 /*
  * The CanvasService maintains the data of the cards to show on the canvas,
@@ -120,6 +125,33 @@ export class CanvasService {
   deselectCards() {
     for (let i = 0; i < this.cards.length; i++) {
       this.cards.get(i).selected = false;
+    }
+  }
+
+  getCardById(id: string): Card {
+    // TODO(eyuelt): change CollaborativeList to CollaborativeMap
+    let cardsArray = this.cards.asArray();
+    for (let card of cardsArray) {
+      if (card.id === id) {
+        return card;
+      }
+    }
+    return null;
+  }
+
+  connectArrowAndCard(arrow: Arrow, card: Card, arrowConnection: ArrowConnectionType) {
+    if (arrowConnection === ArrowConnectionType.INCOMING) {
+      if (arrow.toCard) {
+        arrow.toCard.incomingArrows.removeValue(arrow);
+      }
+      arrow.toCard = card;
+      card.incomingArrows.push(arrow);
+    } else if (arrowConnection === ArrowConnectionType.OUTGOING) {
+      if (arrow.fromCard) {
+        arrow.fromCard.outgoingArrows.removeValue(arrow);
+      }
+      arrow.fromCard = card;
+      card.outgoingArrows.push(arrow);
     }
   }
 

--- a/src/client/app/graph/canvas/canvas.service.ts
+++ b/src/client/app/graph/canvas/canvas.service.ts
@@ -14,7 +14,9 @@ export type ViewportCoord = Point;
 // A point in the coordinate system of the canvas.
 export type CanvasCoord = Point;
 
-// Specifies the type of connection an arrow has to a card.
+// Specifies the type of connection an arrow has to a card. Note that an arrow
+// may be connected to up to two cards, so it could have an INCOMING connection
+// and an OUTGOING connection.
 export enum ArrowConnectionType {
   INCOMING,
   OUTGOING

--- a/src/client/app/graph/card/card.component.html
+++ b/src/client/app/graph/card/card.component.html
@@ -25,17 +25,17 @@
         style="filter:url(#drop-shadow)"
         attr.rx="{{cornerRadius}}"
         attr.ry="{{cornerRadius}}"
-        attr.width="{{size.width}}"
-        attr.height="{{size.height}}">
+        attr.width="{{card.size.width}}"
+        attr.height="{{card.size.height}}">
   </rect>
   <foreignObject x="0"
                  y="0"
-                 attr.width="{{size.width}}"
-                 attr.height="{{size.height}}">
+                 attr.width="{{card.size.width}}"
+                 attr.height="{{card.size.height}}">
     <xhtml:div class="textarea-container">
       <xhtml:textarea xmlns="http://www.w3.org/1999/xhtml"
                       #cardTextArea
-                      [style.width] = "size.width + 'px'"
+                      [style.width] = "card.size.width + 'px'"
                       [ngModel]="card.text"
                       maxlength="36"
                       (focus)="onCardTextareaFocus()"

--- a/src/client/app/graph/card/card.component.ts
+++ b/src/client/app/graph/card/card.component.ts
@@ -15,6 +15,7 @@ import {
 } from '../../service/google-realtime.service';
 import { Card } from '../../model/card';
 import {Size} from '../../model/geometry';
+import {Arrow} from '../../model/arrow';
 
 /**
  * This class represents the Card component.
@@ -109,21 +110,23 @@ export class CardComponent implements OnInit {
       const newCardPosition =
         this.canvasService.viewportCoordToCanvasCoord(this.position);
       this.card.position = {x: newCardPosition.x, y: newCardPosition.y};
-      // TODO: move all associated arrows too
-      let inArrow = this.card.incomingArrow;
-      if (inArrow) {
-        inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + 40};
-        if (inArrow.fromCardId === null) {
-          inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + 40};
+      // Move all associated arrows too
+      this.card.incomingArrows.asArray().forEach((inArrow: Arrow) => {
+        if (inArrow) {
+          inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + 40};
+          if (inArrow.fromCardId === null) {
+            inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + 40};
+          }
         }
-      }
-      let outArrow = this.card.outgoingArrow;
-      if (outArrow) {
-        outArrow.tailPosition = {x: newCardPosition.x + 60, y: newCardPosition.y + 40};
-        if (outArrow.toCardId === null) {
-          outArrow.tipPosition = {x: newCardPosition.x + 60 + 50, y: newCardPosition.y + 40};
+      });
+      this.card.outgoingArrows.asArray().forEach((outArrow: Arrow) => {
+        if (outArrow) {
+          outArrow.tailPosition = { x: newCardPosition.x + 60, y: newCardPosition.y + 40 };
+          if (outArrow.toCardId === null) {
+            outArrow.tipPosition = { x: newCardPosition.x + 60 + 50, y: newCardPosition.y + 40 };
+          }
         }
-      }
+      });
       this.lastDragPnt = newDragPnt;
     }
   }

--- a/src/client/app/graph/card/card.component.ts
+++ b/src/client/app/graph/card/card.component.ts
@@ -109,17 +109,29 @@ export class CardComponent implements OnInit {
       // Move all associated arrows too
       this.card.incomingArrows.asArray().forEach((inArrow: Arrow) => {
         if (inArrow) {
-          inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + this.card.size.height/2};
+          inArrow.tipPosition = {
+            x: newCardPosition.x,
+            y: newCardPosition.y + this.card.size.height / 2
+          };
           if (inArrow.fromCard === null) {
-            inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + this.card.size.height/2};
+            inArrow.tailPosition = {
+              x: newCardPosition.x - 50,
+              y: newCardPosition.y + this.card.size.height / 2
+            };
           }
         }
       });
       this.card.outgoingArrows.asArray().forEach((outArrow: Arrow) => {
         if (outArrow) {
-          outArrow.tailPosition = { x: newCardPosition.x + this.card.size.width, y: newCardPosition.y + this.card.size.height/2 };
+          outArrow.tailPosition = {
+            x: newCardPosition.x + this.card.size.width,
+            y: newCardPosition.y + this.card.size.height / 2
+          };
           if (outArrow.toCard === null) {
-            outArrow.tipPosition = { x: newCardPosition.x + this.card.size.width + 50, y: newCardPosition.y + this.card.size.height/2 };
+            outArrow.tipPosition = {
+              x: newCardPosition.x + this.card.size.width + 50,
+              y: newCardPosition.y + this.card.size.height / 2
+            };
           }
         }
       });

--- a/src/client/app/graph/card/card.component.ts
+++ b/src/client/app/graph/card/card.component.ts
@@ -14,7 +14,6 @@ import {
   OBJECT_CHANGED
 } from '../../service/google-realtime.service';
 import { Card } from '../../model/card';
-import {Size} from '../../model/geometry';
 import {Arrow} from '../../model/arrow';
 
 /**
@@ -29,7 +28,6 @@ import {Arrow} from '../../model/arrow';
 export class CardComponent implements OnInit {
 
   // The card data to render on the canvas.
-  // TODO(girum): Give these realtime custom models real static types.
   @Input() card: Card = null;
 
   // A function pointer to the CanvasService's "getBounds()" function.
@@ -39,8 +37,6 @@ export class CardComponent implements OnInit {
   scale: number = 1;
   // The current display position in the viewport's coordinate space.
   position: ViewportCoord = {x:0, y:0};
-  // The size of the card in the canvas' coordinate space.
-  size: Size = {width:120, height:160};
   // The radius of the rounded corners in the canvas' coordinate space.
   cornerRadius: number = 1;
 
@@ -113,17 +109,17 @@ export class CardComponent implements OnInit {
       // Move all associated arrows too
       this.card.incomingArrows.asArray().forEach((inArrow: Arrow) => {
         if (inArrow) {
-          inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + 40};
+          inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + this.card.size.height/2};
           if (inArrow.fromCard === null) {
-            inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + 40};
+            inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + this.card.size.height/2};
           }
         }
       });
       this.card.outgoingArrows.asArray().forEach((outArrow: Arrow) => {
         if (outArrow) {
-          outArrow.tailPosition = { x: newCardPosition.x + 60, y: newCardPosition.y + 40 };
+          outArrow.tailPosition = { x: newCardPosition.x + this.card.size.width, y: newCardPosition.y + this.card.size.height/2 };
           if (outArrow.toCard === null) {
-            outArrow.tipPosition = { x: newCardPosition.x + 60 + 50, y: newCardPosition.y + 40 };
+            outArrow.tipPosition = { x: newCardPosition.x + this.card.size.width + 50, y: newCardPosition.y + this.card.size.height/2 };
           }
         }
       });

--- a/src/client/app/graph/card/card.component.ts
+++ b/src/client/app/graph/card/card.component.ts
@@ -114,7 +114,7 @@ export class CardComponent implements OnInit {
       this.card.incomingArrows.asArray().forEach((inArrow: Arrow) => {
         if (inArrow) {
           inArrow.tipPosition = {x: newCardPosition.x, y: newCardPosition.y + 40};
-          if (inArrow.fromCardId === null) {
+          if (inArrow.fromCard === null) {
             inArrow.tailPosition = {x: newCardPosition.x - 50, y: newCardPosition.y + 40};
           }
         }
@@ -122,7 +122,7 @@ export class CardComponent implements OnInit {
       this.card.outgoingArrows.asArray().forEach((outArrow: Arrow) => {
         if (outArrow) {
           outArrow.tailPosition = { x: newCardPosition.x + 60, y: newCardPosition.y + 40 };
-          if (outArrow.toCardId === null) {
+          if (outArrow.toCard === null) {
             outArrow.tipPosition = { x: newCardPosition.x + 60 + 50, y: newCardPosition.y + 40 };
           }
         }

--- a/src/client/app/graph/graph.component.ts
+++ b/src/client/app/graph/graph.component.ts
@@ -45,42 +45,65 @@ export class GraphComponent implements OnInit, OnDestroy {
       let numCards = model.getRoot().get('cards').length;
 
       let card1 = model.create(Card);
-      card1.position = {x: 10 + numCards * 5, y: 10 + numCards * 5};
-      card1.text = 'card #' + numCards;
+      card1.position = {x: 10 + numCards * 20, y: 10 + numCards * 20};
+      card1.text = 'card #' + numCards++;
       card1.selected = false;
       model.getRoot().get('cards').push(card1);
 
       let card2 = model.create(Card);
-      card2.position = {x: 10 + numCards * 5, y: 10 + numCards * 5};
-      card2.text = 'card #' + (numCards+1);
+      card2.position = {x: card1.position.x + 200, y: card1.position.y + 100};
+      card2.text = 'card #' + numCards++;
       card2.selected = false;
       model.getRoot().get('cards').push(card2);
+
+      let card3 = model.create(Card);
+      card3.position = {x: card1.position.x, y: card1.position.y + 200};
+      card3.text = 'card #' + numCards++;
+      card3.selected = false;
+      model.getRoot().get('cards').push(card3);
 
       let arrow1 = model.create(Arrow);
       arrow1.fromCard = null;
       arrow1.toCard = card1;
-      arrow1.tailPosition = {x: card1.position.x - 50, y: card1.position.y + 40};
-      arrow1.tipPosition = {x: card1.position.x, y: card1.position.y + 40};
+      arrow1.tailPosition = {x: card1.position.x - 50, y: card1.position.y + 80};
+      arrow1.tipPosition = {x: card1.position.x, y: card1.position.y + 80};
       model.getRoot().get('arrows').push(arrow1);
 
       let arrow2 = model.create(Arrow);
       arrow2.fromCard = card1;
       arrow2.toCard = card2;
-      arrow2.tailPosition = {x: card1.position.x + 60, y: card1.position.y + 40};
-      arrow2.tipPosition = {x: card2.position.x, y: card2.position.y + 40};
+      arrow2.tailPosition = {x: card1.position.x + 120, y: card1.position.y + 80};
+      arrow2.tipPosition = {x: card2.position.x, y: card2.position.y + 80};
       model.getRoot().get('arrows').push(arrow2);
 
       let arrow3 = model.create(Arrow);
       arrow3.fromCard = card2;
       arrow3.toCard = null;
-      arrow3.tailPosition = {x: card2.position.x + 60, y: card2.position.y + 40};
-      arrow3.tipPosition = {x: card2.position.x + 60 + 50, y: card2.position.y + 40};
+      arrow3.tailPosition = {x: card2.position.x + 120, y: card2.position.y + 80};
+      arrow3.tipPosition = {x: card2.position.x + 120 + 50, y: card2.position.y + 80};
       model.getRoot().get('arrows').push(arrow3);
+
+      let arrow4 = model.create(Arrow);
+      arrow4.fromCard = null;
+      arrow4.toCard = card3;
+      arrow4.tailPosition = {x: card3.position.x - 50, y: card3.position.y + 80};
+      arrow4.tipPosition = {x: card3.position.x, y: card3.position.y + 80};
+      model.getRoot().get('arrows').push(arrow4);
+
+      let arrow5 = model.create(Arrow);
+      arrow5.fromCard = card3;
+      arrow5.toCard = card2;
+      arrow5.tailPosition = {x: card3.position.x + 120, y: card3.position.y + 80};
+      arrow5.tipPosition = {x: card2.position.x, y: card2.position.y + 80};
+      model.getRoot().get('arrows').push(arrow5);
 
       card1.incomingArrows.push(arrow1);
       card1.outgoingArrows.push(arrow2);
       card2.incomingArrows.push(arrow2);
       card2.outgoingArrows.push(arrow3);
+      card3.incomingArrows.push(arrow4);
+      card3.outgoingArrows.push(arrow5);
+      card2.incomingArrows.push(arrow5);
     });
   }
 

--- a/src/client/app/graph/graph.component.ts
+++ b/src/client/app/graph/graph.component.ts
@@ -77,10 +77,10 @@ export class GraphComponent implements OnInit, OnDestroy {
       arrow3.tipPosition = {x: card2.position.x + 60 + 50, y: card2.position.y + 40};
       model.getRoot().get('arrows').push(arrow3);
 
-      card1.incomingArrow = arrow1;
-      card1.outgoingArrow = arrow2;
-      card2.incomingArrow = arrow2;
-      card2.outgoingArrow = arrow3;
+      card1.incomingArrows.push(arrow1);
+      card1.outgoingArrows.push(arrow2);
+      card2.incomingArrows.push(arrow2);
+      card2.outgoingArrows.push(arrow3);
     });
   }
 

--- a/src/client/app/graph/graph.component.ts
+++ b/src/client/app/graph/graph.component.ts
@@ -57,22 +57,22 @@ export class GraphComponent implements OnInit, OnDestroy {
       model.getRoot().get('cards').push(card2);
 
       let arrow1 = model.create(Arrow);
-      arrow1.fromCardId = null;
-      arrow1.toCardId = numCards;
+      arrow1.fromCard = null;
+      arrow1.toCard = card1;
       arrow1.tailPosition = {x: card1.position.x - 50, y: card1.position.y + 40};
       arrow1.tipPosition = {x: card1.position.x, y: card1.position.y + 40};
       model.getRoot().get('arrows').push(arrow1);
 
       let arrow2 = model.create(Arrow);
-      arrow2.fromCardId = numCards;
-      arrow2.toCardId = numCards+1;
+      arrow2.fromCard = card1;
+      arrow2.toCard = card2;
       arrow2.tailPosition = {x: card1.position.x + 60, y: card1.position.y + 40};
       arrow2.tipPosition = {x: card2.position.x, y: card2.position.y + 40};
       model.getRoot().get('arrows').push(arrow2);
 
       let arrow3 = model.create(Arrow);
-      arrow3.fromCardId = numCards+1;
-      arrow3.toCardId = null;
+      arrow3.fromCard = card2;
+      arrow3.toCard = null;
       arrow3.tailPosition = {x: card2.position.x + 60, y: card2.position.y + 40};
       arrow3.tipPosition = {x: card2.position.x + 60 + 50, y: card2.position.y + 40};
       model.getRoot().get('arrows').push(arrow3);

--- a/src/client/app/model/arrow.ts
+++ b/src/client/app/model/arrow.ts
@@ -1,4 +1,5 @@
 import { Point } from './geometry';
+import { Card } from './card';
 import { CollaborativeObjectModel } from './collaborative-object-model';
 
 export class Arrow extends CollaborativeObjectModel {
@@ -6,8 +7,8 @@ export class Arrow extends CollaborativeObjectModel {
   // Collaborative fields
   tailPosition: Point;
   tipPosition: Point;
-  fromCardId: string;
-  toCardId: string;
+  fromCard: Card;
+  toCard: Card;
 
   static registerModel() {
     super.registerModel();
@@ -15,9 +16,9 @@ export class Arrow extends CollaborativeObjectModel {
       gapi.drive.realtime.custom.collaborativeField('tailPosition');
     this.prototype.tipPosition =
       gapi.drive.realtime.custom.collaborativeField('tipPosition');
-    this.prototype.fromCardId =
-      gapi.drive.realtime.custom.collaborativeField('fromCardId');
-    this.prototype.toCardId =
-      gapi.drive.realtime.custom.collaborativeField('toCardId');
+    this.prototype.fromCard =
+      gapi.drive.realtime.custom.collaborativeField('fromCard');
+    this.prototype.toCard =
+      gapi.drive.realtime.custom.collaborativeField('toCard');
   }
 };

--- a/src/client/app/model/card.ts
+++ b/src/client/app/model/card.ts
@@ -1,9 +1,10 @@
-import { Point } from './geometry';
+import { Point, Size } from './geometry';
 import { Arrow } from './arrow';
 import { CollaborativeObjectModel } from './collaborative-object-model';
 
 export class Card extends CollaborativeObjectModel {
   protected static modelName = 'Card';
+  readonly size: Size = {width:120, height:160};
   // Collaborative fields
   position: Point;
   text: string;

--- a/src/client/app/model/card.ts
+++ b/src/client/app/model/card.ts
@@ -1,6 +1,7 @@
 import { Point, Size } from './geometry';
 import { Arrow } from './arrow';
 import { CollaborativeObjectModel } from './collaborative-object-model';
+import CollaborativeList = gapi.drive.realtime.CollaborativeList;
 
 export class Card extends CollaborativeObjectModel {
   protected static modelName = 'Card';
@@ -9,14 +10,16 @@ export class Card extends CollaborativeObjectModel {
   position: Point;
   text: string;
   selected: boolean;
-  incomingArrows: gapi.drive.realtime.CollaborativeList<Arrow>;
-  outgoingArrows: gapi.drive.realtime.CollaborativeList<Arrow>;
+  // TODO(eyuelt): Change these to normal arrays since CollaborativeLists
+  // inside custom collaborative objects are not actually collaborative.
+  incomingArrows: CollaborativeList<Arrow>;
+  outgoingArrows: CollaborativeList<Arrow>;
 
   initializeModel() {
     super.initializeModel();
-    var model = gapi.drive.realtime.custom.getModel(this);
-    this.incomingArrows = model.createList() as gapi.drive.realtime.CollaborativeList<Arrow>;
-    this.outgoingArrows = model.createList() as gapi.drive.realtime.CollaborativeList<Arrow>;
+    const model = gapi.drive.realtime.custom.getModel(this);
+    this.incomingArrows = model.createList() as CollaborativeList<Arrow>;
+    this.outgoingArrows = model.createList() as CollaborativeList<Arrow>;
   }
 
   static registerModel() {

--- a/src/client/app/model/card.ts
+++ b/src/client/app/model/card.ts
@@ -5,7 +5,10 @@ import CollaborativeList = gapi.drive.realtime.CollaborativeList;
 
 export class Card extends CollaborativeObjectModel {
   protected static modelName = 'Card';
-  readonly size: Size = {width:120, height:160};
+  readonly size: Size = {
+    width: 120,
+    height: 160
+  };
   // Collaborative fields
   position: Point;
   text: string;

--- a/src/client/app/model/card.ts
+++ b/src/client/app/model/card.ts
@@ -8,8 +8,15 @@ export class Card extends CollaborativeObjectModel {
   position: Point;
   text: string;
   selected: boolean;
-  incomingArrow: Arrow;
-  outgoingArrow: Arrow;
+  incomingArrows: gapi.drive.realtime.CollaborativeList<Arrow>;
+  outgoingArrows: gapi.drive.realtime.CollaborativeList<Arrow>;
+
+  initializeModel() {
+    super.initializeModel();
+    var model = gapi.drive.realtime.custom.getModel(this);
+    this.incomingArrows = model.createList() as gapi.drive.realtime.CollaborativeList<Arrow>;
+    this.outgoingArrows = model.createList() as gapi.drive.realtime.CollaborativeList<Arrow>;
+  }
 
   static registerModel() {
     super.registerModel();
@@ -19,9 +26,9 @@ export class Card extends CollaborativeObjectModel {
       gapi.drive.realtime.custom.collaborativeField('text');
     this.prototype.selected =
       gapi.drive.realtime.custom.collaborativeField('selected');
-    this.prototype.incomingArrow =
-      gapi.drive.realtime.custom.collaborativeField('incomingArrow');
-    this.prototype.outgoingArrow =
-      gapi.drive.realtime.custom.collaborativeField('outgoingArrow');
+    this.prototype.incomingArrows =
+      gapi.drive.realtime.custom.collaborativeField('incomingArrows');
+    this.prototype.outgoingArrows =
+      gapi.drive.realtime.custom.collaborativeField('outgoingArrows');
   }
 };

--- a/tools/manual_typings/project/document.d.ts
+++ b/tools/manual_typings/project/document.d.ts
@@ -1,0 +1,3 @@
+interface Document {
+  elementsFromPoint(x: number, y: number): Element[];
+}

--- a/tools/manual_typings/project/gapi.drive.realtime.custom.d.ts
+++ b/tools/manual_typings/project/gapi.drive.realtime.custom.d.ts
@@ -6,4 +6,6 @@ declare namespace gapi.drive.realtime.custom {
       typename: string): void;
 
   export function setInitializer(type: any, initializerFn: () => void): void;
+
+  export function getModel(obj: Object): gapi.drive.realtime.Model;
 }


### PR DESCRIPTION
Now you can drag arrows around and dragging an arrow onto a card will connect them.

There's still work to be done, like being able to drag the tail (if we want to be able to do that) and expanding the click target because the arrow itself is really thin, but this handles the main functionality.

Some of the stuff is kind of messy and will be cleaned up in an upcoming PR. I split them up to make reviewing easier.